### PR TITLE
空き家の詳細画面にメッセージのボタンを追加 + messages、conversationの画面デザインの変更　Issue/#79

### DIFF
--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -1,3 +1,24 @@
-// Place all the styles related to the Conversations controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+.conversation_from_user_field {
+  list-style: none;
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid #dddddd;
+  border-radius: 7px;
+}
+
+.conversation_to_admin_field {
+  list-style: none;
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid #dddddd;
+  border-radius: 7px;
+}
+
+.conversation_to_admin_field a {
+  color: #d43f3a;
+}
+
+.message_time {
+  float: right;
+  padding-right: 10px;
+}

--- a/app/assets/stylesheets/houses.scss
+++ b/app/assets/stylesheets/houses.scss
@@ -93,3 +93,16 @@ img.index-image {
 .favorite_button-field {
   padding-top: 7px;
 }
+
+.message_btn_filed {
+  margin: 20px 0px;
+  text-align: center;
+}
+
+#detail-map {
+  margin-bottom: 20px;
+}
+
+.table {
+  margin-bottom: 0px;
+}

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -1,3 +1,33 @@
-// Place all the styles related to the messages controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+#message_body {
+  width: 460px;
+  height: 100px !important;
+}
+
+.message_body {
+  padding-right: 0px;
+  margin-top: 30px;
+  overflow: hidden;
+  text-align: center;
+}
+
+.message_body_btn {
+  float: right;
+}
+
+div[class*="messages_user_"] {
+  margin: 15px 0px 15px 400px;
+  background-color: #f7f7f7;
+  height: auto;
+  padding: 20px 20px 20px 20px;
+  border-radius: 6px;
+  word-wrap: break-word;
+}
+
+div[class*="messages_admin"] {
+  margin: 15px 400px 15px 0px;
+  background-color: #dadada;
+  height: auto;
+  padding: 20px 0px 20px 20px;
+  border-radius: 6px;
+  word-wrap: break-word;
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,10 +3,10 @@ class MessagesController < ApplicationController
     @message = Message.new
     if current_user.status_admin?
       @conversation = Conversation.find_by(sender_id: params[:user_id])
-      @messages = Message.where("(user_id = ?) OR (user_id = ?)", params[:user_id], User.admin_user)
+      @messages = @conversation.messages
     else
       @conversation = Conversation.find_or_create_by(sender_id: current_user.id, recipient_id: User.admin_user)
-      @messages = Message.where("(user_id = ?) OR (user_id = ?)", current_user.id, User.admin_user)
+      @messages = @conversation.messages
     end
   end
 

--- a/app/helpers/conversations_helper.rb
+++ b/app/helpers/conversations_helper.rb
@@ -1,2 +1,5 @@
 module ConversationsHelper
+  def admin_status
+    3
+  end
 end

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,7 +1,31 @@
 <div class="container">
   <div class="wrapper col-md-8 col-md-offset-2 col-sm-10">
     <% @conversations.each do |conversation| %>
-      <li><%= link_to conversation.sender.name, messages_path(user_id: conversation.sender.id) %></li>
+      <% unless conversation.messages.empty? %>
+          <% if conversation.messages.last.user_id === admin_status %>
+            <div class="conversation_from_user_field">
+              <li>
+                <%= link_to conversation.sender.name, messages_path(user_id: conversation.sender.id) %>
+                <div class="message_time">
+                  <%= '最終投稿時間: ' + conversation.messages.last.created_at.strftime('%Y/%m/%d %H:%M') %>
+                </div>
+              </li>
+            </div>
+         <% else %>
+          <div class="conversation_to_admin_field">
+            <li>
+              <%= link_to conversation.sender.name, messages_path(user_id: conversation.sender.id) %>
+              <div class="message_time">
+                <%= '最終投稿時間: ' + conversation.messages.last.created_at.strftime('%Y/%m/%d %H:%M') %>
+              </div>
+            </li>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="conversation_from_user_field">
+          <li><%= link_to conversation.sender.name, messages_path(user_id: conversation.sender.id) %></li>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/houses/show.html.erb
+++ b/app/views/houses/show.html.erb
@@ -83,6 +83,11 @@
             </table>
            </div>
           </div>
+          <div class="message_btn_filed">
+            <%= link_to messages_path, class: 'btn btn-info btn-lg' do %>
+              <i class="fa fa-search" aria-hidden="true"></i><%= ' ' + @house.title + ' についてもっと調べる' %>
+            <% end %>
+          </div>
           <div id="detail-map"></div>
         </div>
       <hr>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,5 +1,10 @@
 <%= form_for(@message, url: choose_new_or_edit ) do |f| %>
+  <div class="message_body col-md-8 col-md-offset-2 col-sm-10">
     <%= f.hidden_field :user_id, value: params[:user_id] %>
-    <%= f.text_field :body %>
-    <%= f.submit '登録', class: 'btn btn-primary' %>
+    <%= f.text_area :body %>
+    <br>
+    <div class="message_body_btn">
+      <%= f.submit '送信', class: 'btn btn-primary' %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,23 +1,26 @@
 <div class="container">
   <div class="wrapper col-md-8 col-md-offset-2 col-sm-10">
+    <% unless current_user.status_admin? %>
+      <h3>事務局にメッセージする</h3>
+    <% end %>
     <% @messages.each do |message| %>
         <div class="item">
           <% if message.user.id == current_user.id %>
-            <div class="message_<%= current_user.id %>" style="text-align: right">
-              <div class="message_header"><strong><%= message.user.name %></strong> <%= message.created_at %></div>
+            <div class="messages_user_<%= current_user.id %>" style="text-align: right">
+              <div class="message_header"><strong><%= message.user.name %></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %></div>
               <div class="list">
                 <div class="item">
-                  <i class="right triangle icon"></i>
+                  <br>
                   <%= message.body %>
                 </div>
               </div>
             </div>
           <%  else %>
-            <div class="message_admin" style="text-align: left">
-              <div class="message_header"><strong><%= message.user.name %></strong> <%= message.created_at %></div>
+            <div class="messages_admin" style="text-align: left">
+              <div class="message_header"><strong><%= message.user.name %></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %></div>
               <div class="list">
                 <div class="item">
-                  <i class="right triangle icon"></i>
+                  <br>
                   <%= message.body %>
                 </div>
               </div>


### PR DESCRIPTION
#79 #80

## 実装したもの
- 空き家の詳細画面にメッセージのボタンを追加
- messagesの表示デザインを修正
- 管理者用のconversation一覧の画面デザインを修正
