### PR TITLE
conversationページに管理者のみアクセスするように設定

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -1,4 +1,6 @@
 class ConversationsController < ApplicationController
+  load_and_authorize_resource
+  
   def index
     @conversations = Conversation.where.not(sender_id: User.admin_user )
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,8 +7,6 @@ class Ability
     #   user ||= User.new # guest user (not logged in)
       if user.status_admin?
         can :manage, :all
-      else
-        can :read, :all
       end
     #
     # The first argument to `can` is the action you are giving the user


### PR DESCRIPTION
## 実装したもの

- 管理者のみ管理ページを閲覧
- 管理者のみメッセージ一覧画面の閲覧