### PR TITLE
 メッセージ画面のレイアウト修正 1.5h Issue#109

### DIFF
--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -1,6 +1,5 @@
 #message_body {
-  width: 460px;
-  height: 230px !important;
+  height: 200px !important;
 }
 
 .message_body {
@@ -15,21 +14,19 @@
 }
 
 div[class*="messages_user_"] {
-  margin: 15px 0px 15px 400px;
   height: auto;
+  margin-top: 15px;
   padding: 20px 20px 20px 20px;
   border-radius: 6px;
   word-wrap: break-word;
   border: 1px solid #cccccc;
-  width: 500px;
 }
 
 div[class*="messages_admin"] {
-  margin: 15px 400px 15px 0px;
   height: auto;
+  margin-top: 15px;
   padding: 20px 20px 20px 20px;
   border-radius: 6px;
   word-wrap: break-word;
   border: 1px solid #cccccc;
-  width: 500px;
 }

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
-  <div class="col-xs-12 col-md-8 col-md-offset-2">
+  <div class="col-xs-12 col-md-6 col-md-offset-3">
     <% @conversations.each do |conversation| %>
       <% unless conversation.messages.empty? %>
-          <% if conversation.messages.last.user_id === admin_status %>
+          <% if conversation.messages.last.user.status === admin_status %>
             <div class="conversation_from_user_field">
               <li>
                 <%= link_to conversation.sender.name, messages_path(user_id: conversation.sender.id) %>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@message, url: choose_new_or_edit ) do |f| %>
-  <div class="message_body col-md-8 col-md-offset-2 col-sm-10">
+  <div class="message_body col-xs-10 col-xs-offset-1 col-md-6 col-md-offset-3">
     <%= f.hidden_field :user_id, value: params[:user_id] %>
-    <%= f.text_area :body %>
+    <%= f.text_area :body, class: "form-control", size: "100x50" %>
     <br>
     <div class="message_body_btn">
       <%= f.submit '送信', class: 'btn btn-primary' %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,12 +1,12 @@
 <div class="container">
-  <div class="col-xs-12 col-md-8 col-md-offset-2">
+  <div class="col-xs-10 col-xs-offset-1 col-md-8 col-md-offset-2">
     <% unless current_user.status_admin? %>
       <h3>事務局にメッセージする</h3>
     <% end %>
     <% @messages.each do |message| %>
         <div class="item">
           <% if message.user.id == current_user.id %>
-            <div class="messages_user_<%= current_user.id %>" style="text-align: right">
+            <div class="messages_user_<%= current_user.id %> col-xs-10 col-xs-offset-2 col-md-8 col-md-offset-4" style="text-align: right">
               <div class="message_header"><strong><%= message.user.name %></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %></div>
               <div class="list">
                 <div class="item">
@@ -16,7 +16,7 @@
               </div>
             </div>
           <%  else %>
-            <div class="messages_admin" style="text-align: left">
+            <div class="messages_admin col-xs-10 col-md-8" style="text-align: left">
               <div class="message_header"><strong><%= message.user.name %></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %></div>
               <div class="list">
                 <div class="item">

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -7,7 +7,13 @@
         <div class="item">
           <% if message.user.id == current_user.id %>
             <div class="messages_user_<%= current_user.id %> col-xs-10 col-xs-offset-2 col-md-8 col-md-offset-4" style="text-align: right">
-              <div class="message_header"><strong><%= message.user.name %></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %></div>
+              <div class="message_header">
+                <% if current_user.status === admin_status %>
+                    <strong><%= link_to message.user.name, user_path(message.user) %></strong></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %>
+                <% else %>
+                    <strong><%= message.user.name %></strong></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %>
+                <% end %>
+              </div>
               <div class="list">
                 <div class="item">
                   <br>
@@ -17,7 +23,13 @@
             </div>
           <%  else %>
             <div class="messages_admin col-xs-10 col-md-8" style="text-align: left">
-              <div class="message_header"><strong><%= message.user.name %></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %></div>
+              <div class="message_header">
+                <% if current_user.status === admin_status %>
+                  <strong><%= link_to message.user.name, user_path(message.user) %></strong></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %>
+                <% else %>
+                  <strong><%= message.user.name %></strong></strong><br><%= message.created_at.strftime('%Y/%m/%d %H:%M') %>
+                <% end %>
+              </div>
               <div class="list">
                 <div class="item">
                   <br>


### PR DESCRIPTION
#109

## 実装した内容

- メッセージ画面のレイアウトを修正（レスポンシブにも対応）
- 管理者のメッセージ確認画面にユーザーへのリンクを追加
- 未返信のユーザーを赤色に表示