### PR TITLE
house一覧画面のレイアウト修正（レスポンシブ対応）50min

### DIFF
--- a/app/assets/stylesheets/houses.scss
+++ b/app/assets/stylesheets/houses.scss
@@ -24,9 +24,7 @@
 }
 
 img.index-image {
-  margin-right: 15px;
-  width: 260px;
-  float: left;
+  width: 100%;
 }
 
 .show-images {
@@ -116,20 +114,25 @@ img.index-image {
 }
 
 .index-house-body {
+  margin-bottom: -10px;
   padding: 0px 0px 0px 0px;
   text-align: left;
-  // overflow: hidden;
+  overflow: hidden;
 }
 
 .index-house-body-left {
-  width:35%;
-  height: 150px;
-  display: block;
+  margin-left: 0px;
+  padding: 0px 0px;
+  //width:35%;
+  //height: 150px;
+  //display: block;
 }
 
 .index-house-body-right {
-  width:55%;
-  height: 150px;
+  margin-left: 0px;
+  padding: 5px 5px 5px 5px;
+  //width:55%;
+  //height: 150px;
 }
 
 .index-house-text > p {
@@ -137,9 +140,14 @@ img.index-image {
 }
 
 .house-buttons-field {
+  margin-top: 10px;
   border-top: solid 1px #EBE5DD;
   padding: 8px 20px 15px 20px;
   min-height: 50px;
+}
+
+.house-buttons-field a.btn.btn-default.btn-sm.btn-success {
+  margin-top: 5px;
 }
 
 .link_button-field {
@@ -147,7 +155,7 @@ img.index-image {
 }
 
 .favorite_button-field {
-  padding-top: 7px;
+  margin-top: 10px;
 }
 
 .message_btn_filed {

--- a/app/views/houses/index.html.erb
+++ b/app/views/houses/index.html.erb
@@ -9,13 +9,13 @@
           <li class="fa fa-pencil-square-o">:<%= house.created_at.strftime("%Y-%m-%d") %></li>
           <li class="fa fa-rotate-left">:<%= house.updated_at.strftime("%Y-%m-%d") %></li>
         </div>
-        <div class="index-house-body list-inline">
-          <div class="index-house-body-left">
+        <div class="index-house-body">
+          <div class="index-house-body-left col-xs-12 col-md-6">
                 <% if house.article.images[0] %>
-                  <p><%= image_tag(house.article.images[0].avator, :class => "index-image") %></p>
+                  <%= image_tag(house.article.images[0].avator, :class => "index-image") %>
                 <% end %>
           </div>
-          <div class="index-house-body-right">
+          <div class="index-house-body-right  col-xs-12 col-md-6">
                 <div class="index-house-text">
                   <p><%= truncate(strip_tags(house.article.content)) %></p>
                 </div>


### PR DESCRIPTION
#109 

## 実装した内容

- house一覧画面のレイアウト修正（レスポンシブ対応）

PC
[![https://gyazo.com/8c9c015ab3913125b29a86c6ba9a1e0e](https://i.gyazo.com/8c9c015ab3913125b29a86c6ba9a1e0e.png)](https://gyazo.com/8c9c015ab3913125b29a86c6ba9a1e0e)

スマートフォン
[![https://gyazo.com/331b7476bb68ea36456da3b685e11593](https://i.gyazo.com/331b7476bb68ea36456da3b685e11593.png)](https://gyazo.com/331b7476bb68ea36456da3b685e11593)