### PR TITLE
「もっと調べる」ボタンのスマートフォン画面時表示を修正 16min

### DIFF
--- a/app/views/houses/show.html.erb
+++ b/app/views/houses/show.html.erb
@@ -76,7 +76,7 @@
             </div>
             <div class="message_btn_filed">
               <%= link_to messages_path, class: 'btn btn-info btn-lg' do %>
-                <i class="fa fa-search" aria-hidden="true"></i><%= ' ' + @house.title + ' についてもっと調べる' %>
+                <i class="fa fa-search" aria-hidden="true"></i> <%= @house.title %><br class="visible-xs-block"> についてもっと調べる
               <% end %>
             </div>
           <% else %>


### PR DESCRIPTION
#124

## 実装した内容
- 「もっと調べる」ボタンのスマートフォン画面の時は\<br\>タグを付けることで画面からハミ出ることを回避した

[![https://gyazo.com/89135fc503020a1756fafc07e3f615cf](https://i.gyazo.com/89135fc503020a1756fafc07e3f615cf.png)](https://gyazo.com/89135fc503020a1756fafc07e3f615cf)